### PR TITLE
Document generated-source layout for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,17 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-The primary build definition lives in `build.sbt`, with release automation in `ci.sbt` and Scala release metadata in `versions.yaml`. Generator source code resides under `project/` (e.g., `project/Generator.scala`, `project/Versions.scala`), because the sbt build itself performs code generation. Running the generator writes managed sources into `src/main/scala`, so hand-written library code should remain under `project/` while generated artifacts stay in `target/scala-*/src_managed`. There are currently no persistent sources under `src/test`, so add new test suites there when they become necessary.
+The primary build definition lives in `build.sbt`, with release automation in `ci.sbt` and Scala release metadata in `versions.yaml`. Build-definition Scala code, including the generator invoked by sbt tasks, resides under `project/` (e.g., `project/Generator.scala`, `project/Versions.scala`); `project/*.sbt` configures that build definition's own build. Hand-written runtime library code lives under `src/main/scala`, while generated option traits are emitted under `target/scala-*/src_managed`.
 
 ## Build, Test, and Development Commands
 - `sbt compile` – compile the generator and any generated sources.
 - `sbt downloadScalaCompilerJars` – prefetch all compiler artifacts defined in `versions.yaml`; run this once whenever you update the version list.
 - `sbt getOutputs` – fetch and cache `scalac -help` outputs for the configured versions; use to refresh local caches.
-- `sbt generate` – regenerate option case classes under `src/main/scala/io/github/nafg/scalacoptions`.
-- `sbt test` – executes the (currently empty) test suite; keep it green when adding tests.
+- `sbt generate` – regenerate option traits under `target/scala-*/src_managed/io/github/nafg/scalacoptions`.
+- `sbt test` – run the test suite (currently `src/test/scala/io/github/nafg/scalacoptions/CompilationTests.scala`); use `+test` to run across the cross-build (Scala 2.12 / 2.13 / 3.3).
 
 ## Coding Style & Naming Conventions
-Follow the `.scalafmt.conf` preset (IntelliJ style, 120-column limit, two-space indents). Format changes with a scalafmt-enabled editor or by running the scalafmt CLI before committing. Stick to CamelCase for Scala classes/traits (`Container`, `FlagSegment`) and lowerCamelCase for vals/defs. When adding options, mirror the existing naming in `project/Setting.scala` so generated identifiers remain predictable.
+Follow the `.scalafmt.conf` preset (IntelliJ style, 120-column limit, two-space indents). Format changes with a scalafmt-enabled editor or CLI before committing. Stick to CamelCase for Scala classes/traits (`Container`, `FlagSegment`) and lowerCamelCase for vals/defs. When adding options, mirror the existing naming in `project/Setting.scala` so generated identifiers remain predictable.
 
 ## Testing Guidelines
 When introducing logic changes, add focused unit tests under `src/test/scala` using ScalaTest or MUnit (your choice, but keep the dependency lightweight). Name test files after the type under test, e.g., `GeneratorSpec.scala`. If you touch version parsing or flag handling, run `sbt getOutputs` followed by a regeneration and review the diff to ensure no unintended option churn.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,19 +6,21 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 scalac-options is a build-tool-agnostic Scala library that provides a type-safe DSL for managing scalac compiler options across different Scala versions (2.11+, 3.x). The library automatically generates version-specific option traits by running Scala compilers and parsing their help output.
 
+The library itself cross-builds on Scala 2.12 / 2.13 / 3.3 (see `build.sbt` for exact patch versions). `AGENTS.md` exists with overlapping guidance for other AI tools — when updating workflow info, keep both in sync rather than duplicating new content here.
+
 ## Build Commands
 
 - `sbt compile` - Compile the generator and generated sources
 - `sbt downloadScalaCompilerJars` - Prefetch all compiler artifacts from versions.yaml (run once after updating version list)
 - `sbt getOutputs` - Fetch and cache `scalac -help` outputs for all configured versions
-- `sbt generate` - Regenerate option case classes under `src/main/scala/io/github/nafg/scalacoptions`
+- `sbt generate` - Regenerate option traits under `target/scala-*/src_managed/io/github/nafg/scalacoptions`
 - `sbt test` - Run tests
 
 ## Architecture
 
 ### Code Generation Pipeline
 
-The library uses a meta-build approach where generation happens inside the sbt build itself:
+The library generates version-specific option traits from sbt tasks defined in the build:
 
 1. **versions.yaml** - Defines Scala versions and their help flags (e.g., `-help`, `-X`, `-Y`)
 2. **Generator** (project/Generator.scala) - Orchestrates the generation pipeline:
@@ -26,7 +28,7 @@ The library uses a meta-build approach where generation happens inside the sbt b
    - Runs each compiler with help flags to extract available options
    - Parses outputs using FastParseParser
    - Builds inheritance hierarchy of option traits
-3. **Output** - Generated traits in `src/main/scala/io/github/nafg/scalacoptions/options/`
+3. **Output** - Generated traits in `target/scala-*/src_managed/io/github/nafg/scalacoptions/options/`
 
 ### Key Abstractions
 
@@ -42,7 +44,7 @@ The library uses a meta-build approach where generation happens inside the sbt b
 
 ### Generator Organization
 
-All generator source code lives under `project/` because sbt's meta-build performs the generation:
+Build-definition Scala code lives under `project/` so sbt can use it from build tasks:
 
 - **project/Generator.scala** - Main orchestration logic
 - **project/Versions.scala** - Parses versions.yaml and models version hierarchy
@@ -59,7 +61,7 @@ Hand-written runtime library code in `src/main/scala/`:
 - **WarningsConfig.scala** - DSL for building `-Wconf` strings with filters and actions
 - **VersionOptionsFunction.scala** - Function wrapper for version-specific option selection
 
-Generated traits go to `target/.../src_managed/` but are also written to `src/main/scala/` for publishing.
+Generated traits go to `target/.../src_managed/` and are included as managed sources.
 
 ## Development Workflow
 
@@ -83,4 +85,4 @@ Some options need manual specification in versions.yaml under `settings:` when t
 
 ## Code Style
 
-Follow `.scalafmt.conf` (IntelliJ style, 120-column limit). Generated identifiers mirror compiler option names, converting hyphens to method names (e.g., `-Xlint` becomes `Xlint`).
+Follow `.scalafmt.conf` (IntelliJ style, 120-column limit). Format changes with a scalafmt-enabled editor or CLI. Generated identifiers mirror compiler option names, converting hyphens to method names (e.g., `-Xlint` becomes `Xlint`).


### PR DESCRIPTION
Clarify that project/*.scala contains sbt build-definition code, while project/*.sbt configures the build build. Correct generated option trait paths to sourceManaged and refresh the test and formatting guidance to match the current repository.
