### PR TITLE
Handle choice bullets in scalac help parser

### DIFF
--- a/project/FastParseParser.scala
+++ b/project/FastParseParser.scala
@@ -17,7 +17,9 @@ object FastParseParser {
 
   private def untilLineEnd[_: P] = P(CharsWhile(_ != '\n', 0).! ~ lineEnd)
 
-  private def extraLines[_: P] = P((" ".rep(10) ~ spaces ~ !"-" ~ untilLineEnd).rep)
+  private def settingLineStart[_: P] = P("--" | "-" ~ (CharIn("A-Z") | letters) | "@")
+
+  private def extraLines[_: P] = P((" ".rep(10) ~ spaces ~ !settingLineStart ~ untilLineEnd).rep)
 
   private def letters[_: P] = P(CharsWhile(_.isLetter))
 


### PR DESCRIPTION
Treat indented bullet lines in option descriptions as continuation text unless they look like real scalac option starts. This prevents Scala 3 help sections such as -Yopt-specific choices from truncating generated option traits.
