### PR TITLE
Use console git for read ops to support worktrees

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,10 @@ ThisBuild / organization := "io.github.nafg.scalac-options"
 
 ThisBuild / versionScheme := Some("early-semver")
 
+// sbt-git defaults to JGit for read operations, but JGit 5.13.x doesn't support git worktrees
+// (NoWorkTreeException on load). Shell out to the `git` CLI instead. See sbt/sbt#2323.
+useReadableConsoleGit
+
 val downloadScalaCompilerJars =
   taskKey[Unit]("Download all scala compiler jars")
 downloadScalaCompilerJars := {


### PR DESCRIPTION
## Summary

- Loading sbt in a git worktree fails with `org.eclipse.jgit.errors.NoWorkTreeException: Bare Repository has neither a working tree, nor an index`
- sbt-git 2.1.0 pins JGit 5.13.3, which doesn't handle worktrees; bumping JGit isn't viable here (JGit 6 needs JDK 11, JGit 7 needs JDK 17, CI is on JDK 8)
- `useReadableConsoleGit` switches sbt-git's read-only path to shell out to the `git` CLI, sidestepping JGit entirely

## Test plan

- [x] sbt loads successfully in a git worktree of this repo with the change applied
- [x] CI still passes on JDK 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)