### PR TITLE
chore: tidy scalafmt config and reformat

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,24 +1,38 @@
 version = "3.11.0"
 maxColumn = 120
-runner.dialect = scala212
 preset = IntelliJ
-align.preset = none
-align.tokens = [caseArrow]
-align.multiline = true
-align.openParenDefnSite = true
-danglingParentheses.preset = true
-danglingParentheses.defnSite = false
-verticalMultiline.atDefnSite = true
-spaces.beforeContextBoundColon = Always
-newlines.source = keep
 
-newlines.topLevelStatementBlankLines = [
-  {
-    regex = "^Import",
-    minBreaks = 0,
-    blanks = {after = 2, before = 1}
-  }
-]
+runner {
+  dialect = scala212source3
+}
+
+align {
+  preset = most
+  openParenDefnSite = true
+}
+
+danglingParentheses {
+  defnSite = false
+}
+
+verticalMultiline {
+  atDefnSite = true
+}
+
+spaces {
+  beforeContextBoundColon = Always
+}
+
+newlines {
+  source = keep
+  topLevelStatementBlankLines = [
+    {
+      regex = "^Import",
+      minBreaks = 0,
+      blanks = {after = 2, before = 1}
+    }
+  ]
+}
 
 fileOverride {
   "glob:**/FastParseParser.scala" {

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import scala.concurrent.duration.Duration
 
 
 ThisBuild / crossScalaVersions := Seq("2.12.21", "2.13.18", "3.3.7")
-ThisBuild / scalaVersion := "2.12.21"
+ThisBuild / scalaVersion       := "2.12.21"
 ThisBuild / scalacOptions += "-deprecation"
 
 ThisBuild / organization := "io.github.nafg.scalac-options"
@@ -32,7 +32,7 @@ getOutputs := {
 
   val cacheStore =
     streams.value.cacheStoreFactory.make("scalac-options-outputs")
-  val runCached = Cache.cached[Unit, Generator.Outputs](cacheStore) { _ =>
+  val runCached  = Cache.cached[Unit, Generator.Outputs](cacheStore) { _ =>
     Await.result(Generator.getOutputs, Duration.Inf)
   }
 
@@ -49,7 +49,7 @@ val generate = taskKey[Seq[File]]("Generate code")
 generate := {
   val outputs = getOutputs.value
 
-  val dir = (Compile / sourceManaged).value / "io" / "github" / "nafg" / "scalacoptions"
+  val dir    = (Compile / sourceManaged).value / "io" / "github" / "nafg" / "scalacoptions"
   val result = Generator.parseAllOutputs(outputs)
   result.allContainers.map { c =>
     val file = dir / "options" / (c.name + ".scala")

--- a/ci.sbt
+++ b/ci.sbt
@@ -3,11 +3,11 @@ import _root_.io.github.nafg.mergify.dsl._
 
 inThisBuild(
   List(
-    homepage := Some(url("https://github.com/nafg/scalac-options")),
-    licenses := List(
+    homepage                            := Some(url("https://github.com/nafg/scalac-options")),
+    licenses                            := List(
       "Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0")
     ),
-    developers := List(
+    developers                          := List(
       Developer(
         "nafg",
         "Naftoli Gugenheim",
@@ -19,18 +19,18 @@ inThisBuild(
       (_.map(o =>
         o.copy(dirtySuffix = sbtdynver.GitDirtySuffix(""))
       )),
-    dynverSonatypeSnapshots := true,
-    githubWorkflowScalaVersions := githubWorkflowScalaVersions.value.map(_.replaceFirst("\\d+$", "x")),
+    dynverSonatypeSnapshots             := true,
+    githubWorkflowScalaVersions         := githubWorkflowScalaVersions.value.map(_.replaceFirst("\\d+$", "x")),
     githubWorkflowTargetTags ++= Seq("v*"),
     githubWorkflowPublishTargetBranches := Seq(
       RefPredicate.StartsWith(Ref.Tag("v"))
     ),
-    githubWorkflowPublish := Seq(
+    githubWorkflowPublish               := Seq(
       WorkflowStep.Sbt(
         List("ci-release"),
         env = Map(
-          "PGP_PASSPHRASE" -> "${{ secrets.PGP_PASSPHRASE }}",
-          "PGP_SECRET" -> "${{ secrets.PGP_SECRET }}",
+          "PGP_PASSPHRASE"    -> "${{ secrets.PGP_PASSPHRASE }}",
+          "PGP_SECRET"        -> "${{ secrets.PGP_SECRET }}",
           "SONATYPE_PASSWORD" -> "${{ secrets.SONATYPE_PASSWORD }}",
           "SONATYPE_USERNAME" -> "${{ secrets.SONATYPE_USERNAME }}"
         )

--- a/project/CodeGen.scala
+++ b/project/CodeGen.scala
@@ -6,7 +6,7 @@ object CodeGen {
     val params = setting.flagSegments.toList.collect {
       case FlagSegment.Parameter(name) => name
     }
-    val elems = {
+    val elems  = {
       case class State(finished: List[List[FlagSegment]], current: List[FlagSegment])
       val result =
         setting.flagSegments.foldLeft(State(Nil, Nil)) {

--- a/project/Container.scala
+++ b/project/Container.scala
@@ -36,12 +36,12 @@ object Container {
   lazy val containerLListIso: IsoLList.Aux[
     Container,
     String :*: Option[Container] :*: Seq[Setting] :*: Boolean :*: LNil
-  ] =
+  ]                                                        =
     LList.iso(
       { case Container(name, parent, settings, isConcrete) =>
-        ("name" -> name) :*:
-          ("parent" -> parent) :*:
-          ("settings" -> settings) :*:
+        ("name"         -> name) :*:
+          ("parent"     -> parent) :*:
+          ("settings"   -> settings) :*:
           ("isConcrete" -> isConcrete) :*:
           LNil
       },

--- a/project/FastParseParser.scala
+++ b/project/FastParseParser.scala
@@ -76,7 +76,7 @@ object FastParseParser {
             .collect { case FlagSegment.Literal(text) => text }
             .flatMap(_.split("[:= -]"))
             .filter(_.nonEmpty)
-        val name = words.head + words.tail.map(_.capitalize).mkString
+        val name  = words.head + words.tail.map(_.capitalize).mkString
         Setting(name, flagSegments, description)
       }
   )
@@ -119,12 +119,12 @@ object FastParseParser {
     val textWithoutANSI = ansiRegex.replaceAllIn(text, "")
     fastparse.parse(textWithoutANSI, parser(_), verboseFailures = true) match {
       case Parsed.Success(groups, index) =>
-        val asMap = groups.toMap.map { case (name, settings) =>
+        val asMap     = groups.toMap.map { case (name, settings) =>
           if (name.trim == "Deprecated settings:")
-            name -> settings.map(_.copy(isDeprecated = true))
+            name         -> settings.map(_.copy(isDeprecated = true))
           else name.trim -> settings
         }
-        val all = asMap
+        val all       = asMap
         val remaining = text.drop(index)
         if (remaining.nonEmpty) {
           println("Remaining: ")

--- a/project/FlagSegment.scala
+++ b/project/FlagSegment.scala
@@ -12,9 +12,9 @@ object FlagSegment {
 
   case class Parameter(name: String) extends FlagSegment
 
-  implicit val literalIsoString: IsoString[Literal] =
+  implicit val literalIsoString: IsoString[Literal]       =
     IsoString.iso(_.text, Literal)
-  implicit val parameterIsoString: IsoString[Parameter] =
+  implicit val parameterIsoString: IsoString[Parameter]   =
     IsoString.iso(_.name, Parameter)
   implicit val flagSegmentFormat: JsonFormat[FlagSegment] =
     flatUnionFormat2[FlagSegment, Literal, Parameter]

--- a/project/Generator.scala
+++ b/project/Generator.scala
@@ -66,7 +66,7 @@ object Generator {
       implicit
       seqFormat: JsonFormat[Seq[(K, V)]]): JsonFormat[ListMap[K, V]] =
       new JsonFormat[ListMap[K, V]] {
-        override def write[J](obj: ListMap[K, V], builder: Builder[J]): Unit =
+        override def write[J](obj: ListMap[K, V], builder: Builder[J]): Unit           =
           seqFormat.write(obj.toSeq, builder)
         override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): ListMap[K, V] =
           ListMap(seqFormat.read(jsOpt, unbuilder): _*)
@@ -124,13 +124,11 @@ object Generator {
           settings.tails.filterNot(_.isEmpty).map(t => t.head._1 -> t)
         }
 
-    val commonAll = common(allSettings.map(_._2))
-    val commonEpoch =
-      groupedEpoch.mapValues(settings => common(settings.map(_._2)))
-    val commonMajor =
-      groupedMajor.mapValues(settings => common(settings.map(_._2)))
-    val commonRange =
-      groupedRange.mapValues(settings => common(settings.map(_._2)))
+    val commonAll   = common(allSettings.map(_._2))
+    val commonEpoch = groupedEpoch.mapValues(settings => common(settings.map(_._2)))
+    val commonMajor = groupedMajor.mapValues(settings => common(settings.map(_._2)))
+    val commonRange = groupedRange.mapValues(settings => common(settings.map(_._2)))
+
     println(s"All: ${commonAll.length} common settings")
     for ((v, s) <- commonEpoch) println(s"$v: ${s.length} common settings")
     for (((e, m), s) <- commonMajor)
@@ -138,12 +136,12 @@ object Generator {
     for ((v, s) <- commonRange)
       println(s"${v.versionString}+ ${s.length} common settings")
 
-    val commonContainer =
+    val commonContainer    =
       Container("Common", None, commonAll, isConcrete = false)
-    val epochContainers = commonEpoch.transform { (epoch, settings) =>
+    val epochContainers    = commonEpoch.transform { (epoch, settings) =>
       Container(s"V$epoch", Some(commonContainer), settings, isConcrete = false)
     }
-    val majorContainers = commonMajor.transform {
+    val majorContainers    = commonMajor.transform {
       case ((epoch, major), settings) =>
         val parent = epochContainers(epoch)
         Container(
@@ -153,7 +151,7 @@ object Generator {
           isConcrete = false
         )
     }
-    val rangeContainers =
+    val rangeContainers    =
       commonRange.foldLeft(Map.empty[Versions.Minor, Container]) {
         case (map, (version @ Versions.Minor(epoch, major, minor, prerelease, _, _), settings)) =>
           val parent =
@@ -163,14 +161,14 @@ object Generator {
               }
               .orElse(map.get(version.copy(minor = minor - 1)))
               .getOrElse(majorContainers((epoch, major)))
-          val name =
+          val name   =
             s"V${epoch}_${major}_$minor" + version.prereleaseString.fold("")("_" + _) + "_+"
           map + (version -> Container(name, Some(parent), settings, isConcrete = false))
       }
     val concreteContainers = ListMap(allSettings: _*).transform {
       case (version @ Versions.Minor(epoch, major, minor, _, _, _), settings) =>
         val parent = rangeContainers(version)
-        val name = s"V${epoch}_${major}_$minor" + version.prereleaseString.fold("")("_" + _)
+        val name   = s"V${epoch}_${major}_$minor" + version.prereleaseString.fold("")("_" + _)
         Container(name, Some(parent), settings, isConcrete = true)
     }
 

--- a/project/Setting.scala
+++ b/project/Setting.scala
@@ -15,9 +15,9 @@ object Setting {
   implicit val settingLListIso: IsoLList.Aux[Setting, String :*: Seq[FlagSegment] :*: String :*: Boolean :*: LNil] =
     LList.iso(
       { case Setting(name, flagSegments, description, isDeprecated) =>
-        ("name" -> name) :*:
+        ("name"           -> name) :*:
           ("flagSegments" -> flagSegments) :*:
-          ("description" -> description) :*:
+          ("description"  -> description) :*:
           ("isDeprecated" -> isDeprecated) :*:
           LNil
       },

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -19,7 +19,7 @@ object Versions {
     helpFlags: Seq[String],
     settings: Map[String, Seq[FlagSegment]] = Map.empty) {
     lazy val prereleaseString = prerelease.map { case (let, num) => let + num }
-    lazy val versionString =
+    lazy val versionString    =
       s"$epoch.$major.$minor" + prereleaseString.fold("")("-" + _)
 
     override def toString = versionString
@@ -32,10 +32,10 @@ object Versions {
     ] =
       LList.iso(
         { case Minor(epoch, major, minor, prerelease, helpFlags, settings) =>
-          "version" -> (epoch, major, minor) :*:
+          "version"      -> (epoch, major, minor) :*:
             "prerelease" -> prerelease :*:
-            "helpFlags" -> helpFlags :*:
-            "settings" -> settings :*:
+            "helpFlags"  -> helpFlags :*:
+            "settings"   -> settings :*:
             LNil
         },
         { case (_, (epoch, major, minor)) :*: (_, prerelease) :*: (_, helpFlags) :*: (_, settings) :*: LNil =>
@@ -57,13 +57,13 @@ object Versions {
 
   case class VersionConfig(helpFlags: Seq[String], settings: Map[String, Seq[FlagSegment]] = Map.empty)
   object VersionConfig {
-    private implicit val config = Configuration.default.withDefaults
+    private implicit val config                  = Configuration.default.withDefaults
     implicit val decoder: Decoder[VersionConfig] = deriveConfiguredDecoder
   }
   type VersionFile = SortedMap[Int, SortedMap[Int, Map[String, VersionConfig]]]
 
   def versions = {
-    val data =
+    val data  =
       parser.parse(IO.read(file("versions.yaml")))
         .flatMap(Decoder[VersionFile].decodeJson(_))
         .toTry.get

--- a/project/build-build.sbt
+++ b/project/build-build.sbt
@@ -1,7 +1,7 @@
-libraryDependencies += "com.lihaoyi" %% "fastparse" % "3.1.1"
-libraryDependencies += "org.scalameta" %% "scalameta" % "4.14.7"
-libraryDependencies += "com.lihaoyi" %% "os-lib" % "0.11.8"
-libraryDependencies += "com.lihaoyi" %% "pprint" % "0.9.6"
-libraryDependencies += "io.get-coursier" %% "coursier" % "2.1.24"
+libraryDependencies += "com.lihaoyi"     %% "fastparse" % "3.1.1"
+libraryDependencies += "org.scalameta"   %% "scalameta" % "4.14.7"
+libraryDependencies += "com.lihaoyi"     %% "os-lib"    % "0.11.8"
+libraryDependencies += "com.lihaoyi"     %% "pprint"    % "0.9.6"
+libraryDependencies += "io.get-coursier" %% "coursier"  % "2.1.24"
 
 scalacOptions += "-deprecation"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")
+addSbtPlugin("com.github.sbt"         % "sbt-ci-release"             % "1.11.2")
 addSbtPlugin("io.github.nafg.mergify" % "sbt-mergify-github-actions" % "0.9.0")


### PR DESCRIPTION
Clean up .scalafmt.conf:
- align.preset = most (was none + caseArrow), with scala212source3 dialect
- restructure into HOCON tree form grouped by parent key
- drop redundant settings already implied by presets:
  align.multiline (set by align.preset = most)
  danglingParentheses.preset = true (set by preset = IntelliJ)

Reformat all sources to match the updated style.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
