### PR TITLE
Migrate versions.yaml parsing from circe to zio-json

### DIFF
--- a/project/FlagSegment.scala
+++ b/project/FlagSegment.scala
@@ -1,15 +1,15 @@
-import io.circe.generic.extras.Configuration
-import io.circe.generic.extras.semiauto.deriveConfiguredCodec
-import io.circe.{Codec, Encoder}
 import sjsonnew.BasicJsonProtocol.{flatUnionFormat2, isoStringFormat}
 import sjsonnew.{IsoString, JsonFormat}
+import zio.json.{DeriveJsonCodec, JsonCodec, jsonHint}
 
 
 sealed trait FlagSegment
 
 object FlagSegment {
+  @jsonHint("lit")
   case class Literal(text: String) extends FlagSegment
 
+  @jsonHint("param")
   case class Parameter(name: String) extends FlagSegment
 
   implicit val literalIsoString: IsoString[Literal]       =
@@ -19,24 +19,7 @@ object FlagSegment {
   implicit val flagSegmentFormat: JsonFormat[FlagSegment] =
     flatUnionFormat2[FlagSegment, Literal, Parameter]
 
-  private def renamingConfig(f: PartialFunction[String, String]) =
-    Configuration.default.copy(transformMemberNames = f.orElse { case s => s })
-
-  implicit val codecLiteral: Codec[Literal] = {
-    implicit val config = renamingConfig { case "text" => "lit" }
-    deriveConfiguredCodec
-  }
-
-  implicit val codecParameter: Codec[Parameter] = {
-    implicit val config = renamingConfig { case "name" => "param" }
-    deriveConfiguredCodec
-  }
-
-  implicit val codec: Codec[FlagSegment] = Codec.from(
-    codecLiteral.or(codecParameter.map(identity)),
-    Encoder.instance {
-      case literal: Literal     => codecLiteral(literal)
-      case parameter: Parameter => codecParameter(parameter)
-    }
-  )
+  implicit val literalCodec: JsonCodec[Literal]     = JsonCodec.string.transform(Literal(_), _.text)
+  implicit val parameterCodec: JsonCodec[Parameter] = JsonCodec.string.transform(Parameter(_), _.name)
+  implicit val codec: JsonCodec[FlagSegment]        = DeriveJsonCodec.gen[FlagSegment]
 }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,13 +1,11 @@
 import scala.collection.immutable.SortedMap
 
-import io.circe.Decoder
-import io.circe.generic.extras.Configuration
-import io.circe.generic.extras.semiauto.deriveConfiguredDecoder
-import io.circe.yaml.parser
 import sbt.io.IO
 import sbt.io.syntax.file
 import sjsonnew.BasicJsonProtocol.*
 import sjsonnew.{:*:, IsoLList, LList, LNil}
+import zio.json.*
+import zio.json.yaml.*
 
 
 object Versions {
@@ -57,16 +55,23 @@ object Versions {
 
   case class VersionConfig(helpFlags: Seq[String], settings: Map[String, Seq[FlagSegment]] = Map.empty)
   object VersionConfig {
-    private implicit val config                  = Configuration.default.withDefaults
-    implicit val decoder: Decoder[VersionConfig] = deriveConfiguredDecoder
+    implicit val codec: JsonCodec[VersionConfig] = DeriveJsonCodec.gen[VersionConfig]
   }
   type VersionFile = SortedMap[Int, SortedMap[Int, Map[String, VersionConfig]]]
 
+  implicit def sortedMapEncoder[K : JsonFieldEncoder, V : JsonEncoder]: JsonEncoder[SortedMap[K, V]]            =
+    JsonEncoder[Map[K, V]].contramap(identity)
+  implicit def sortedMapDecoder[K : JsonFieldDecoder : Ordering, V : JsonDecoder]: JsonDecoder[SortedMap[K, V]] =
+    JsonDecoder[Map[K, V]].map(m => SortedMap.empty[K, V] ++ m)
+
+  def parseFile(content: String): VersionFile =
+    content.fromYaml[VersionFile] match {
+      case Right(vf) => vf
+      case Left(err) => sys.error(s"Failed to parse versions.yaml: $err")
+    }
+
   def versions = {
-    val data  =
-      parser.parse(IO.read(file("versions.yaml")))
-        .flatMap(Decoder[VersionFile].decodeJson(_))
-        .toTry.get
+    val data  = parseFile(IO.read(file("versions.yaml")))
     val regex = """(\d+)\.\.(\d+)""".r
     for ((epoch, data) <- data.toSeq)
       yield Epoch(

--- a/project/build-build.sbt
+++ b/project/build-build.sbt
@@ -1,7 +1,8 @@
-libraryDependencies += "com.lihaoyi"     %% "fastparse" % "3.1.1"
-libraryDependencies += "org.scalameta"   %% "scalameta" % "4.14.7"
-libraryDependencies += "com.lihaoyi"     %% "os-lib"    % "0.11.8"
-libraryDependencies += "com.lihaoyi"     %% "pprint"    % "0.9.6"
-libraryDependencies += "io.get-coursier" %% "coursier"  % "2.1.24"
+libraryDependencies += "com.lihaoyi"     %% "fastparse"     % "3.1.1"
+libraryDependencies += "org.scalameta"   %% "scalameta"     % "4.14.7"
+libraryDependencies += "com.lihaoyi"     %% "os-lib"        % "0.11.8"
+libraryDependencies += "com.lihaoyi"     %% "pprint"        % "0.9.6"
+libraryDependencies += "io.get-coursier" %% "coursier"      % "2.1.24"
+libraryDependencies += "dev.zio"         %% "zio-json-yaml" % "0.9.2"
 
 scalacOptions += "-deprecation"


### PR DESCRIPTION
zio-json has a YAML codec that supports both reading and writing,
which sets up a future VersionUpdater task to round-trip the file.

Preserves the existing wire format via @jsonHint("lit"/"param") on
FlagSegment variants and adds SortedMap encoder/decoder instances.
Extracts parseFile so callers other than the sbt task can reuse it.

The sjsonnew codecs in FlagSegment.scala remain — they're used by
sbt's Cache.cached infrastructure for getOutputs, which is a separate
concern from the versions.yaml on-disk format.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
