### PR TITLE
Improve parser Remaining diagnostics

### DIFF
--- a/project/FastParseParser.scala
+++ b/project/FastParseParser.scala
@@ -125,7 +125,7 @@ object FastParseParser {
           else name.trim -> settings
         }
         val all       = asMap
-        val remaining = text.drop(index)
+        val remaining = textWithoutANSI.drop(index)
         if (remaining.nonEmpty) {
           println(s"Remaining from $sourceName: ")
           pprintln(remaining)

--- a/project/FastParseParser.scala
+++ b/project/FastParseParser.scala
@@ -115,7 +115,7 @@ object FastParseParser {
     * @return
     *   a Map of section descriptions to settings within them
     */
-  def parse(text: String): Map[String, Seq[Setting]] = {
+  def parse(text: String, sourceName: String = "unknown source"): Map[String, Seq[Setting]] = {
     val textWithoutANSI = ansiRegex.replaceAllIn(text, "")
     fastparse.parse(textWithoutANSI, parser(_), verboseFailures = true) match {
       case Parsed.Success(groups, index) =>
@@ -127,7 +127,7 @@ object FastParseParser {
         val all       = asMap
         val remaining = text.drop(index)
         if (remaining.nonEmpty) {
-          println("Remaining: ")
+          println(s"Remaining from $sourceName: ")
           pprintln(remaining)
         }
         all

--- a/project/Generator.scala
+++ b/project/Generator.scala
@@ -10,9 +10,11 @@ import sjsonnew.BasicJsonProtocol.*
 object Generator {
   lazy val parser = FastParseParser
 
-  private def parseOutputs(outputs: Seq[String]) =
+  private def parseOutputs(version: Versions.Minor, outputs: Seq[(String, String)]) =
     outputs
-      .flatMap(parser.parse)
+      .flatMap { case (flag, output) =>
+        parser.parse(output, s"$version $flag")
+      }
       .toMap
       .values
       .flatten
@@ -110,7 +112,7 @@ object Generator {
     val allSettings =
       outputs.map { case (version, pages) =>
         val settings =
-          parseOutputs(pages.map(_._2))
+          parseOutputs(version, pages)
             .map { s =>
               version.settings.get(s.name) match {
                 case None           => s


### PR DESCRIPTION
## Summary
- include the Scala version and help flag in parser Remaining diagnostics
- compute Remaining from the same ANSI-stripped text that fastparse parses

## Verification
- sbt generate