### PR TITLE
refactor: remove dead sjsonnew serialization for Container, Setting, Result

### DIFF
--- a/project/Container.scala
+++ b/project/Container.scala
@@ -1,8 +1,3 @@
-import sbt.util.StampedFormat.lazyFormat
-import sjsonnew.BasicJsonProtocol.{BooleanJsonFormat, StringJsonFormat, isolistFormat, optionFormat, seqFormat}
-import sjsonnew._
-
-
 case class Container(name: String, parent: Option[Container], settings: Seq[Setting], isConcrete: Boolean) {
   def inherited(setting: Setting): Option[Setting] =
     parent.flatMap { p =>
@@ -30,26 +25,4 @@ case class Container(name: String, parent: Option[Container], settings: Seq[Sett
       (if (methods.isEmpty) "" else methods.mkString(" {\n", "\n\n", "\n}")) +
       (if (!isConcrete) "" else s"\n\nobject $name extends $name")
   }
-}
-
-object Container {
-  lazy val containerLListIso: IsoLList.Aux[
-    Container,
-    String :*: Option[Container] :*: Seq[Setting] :*: Boolean :*: LNil
-  ]                                                        =
-    LList.iso(
-      { case Container(name, parent, settings, isConcrete) =>
-        ("name"         -> name) :*:
-          ("parent"     -> parent) :*:
-          ("settings"   -> settings) :*:
-          ("isConcrete" -> isConcrete) :*:
-          LNil
-      },
-      { case (_, name) :*: (_, parent) :*: (_, settings) :*: (_, isConcrete) :*: LNil =>
-        Container(name, parent, settings, isConcrete)
-      }
-    )
-  implicit lazy val containerFormat: JsonFormat[Container] = lazyFormat(
-    isolistFormat(containerLListIso)
-  )
 }

--- a/project/Generator.scala
+++ b/project/Generator.scala
@@ -3,9 +3,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
-import sjsonnew.*
-import sjsonnew.BasicJsonProtocol.*
-
 
 object Generator {
   lazy val parser = FastParseParser
@@ -63,28 +60,6 @@ object Generator {
       )
 
   case class Result(allContainers: Seq[Container], versionMap: ListMap[String, String])
-
-  object Result {
-    implicit def listMapFormat[K, V](
-      implicit
-      seqFormat: JsonFormat[Seq[(K, V)]]): JsonFormat[ListMap[K, V]] =
-      new JsonFormat[ListMap[K, V]] {
-        override def write[J](obj: ListMap[K, V], builder: Builder[J]): Unit           =
-          seqFormat.write(obj.toSeq, builder)
-        override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): ListMap[K, V] =
-          ListMap(seqFormat.read(jsOpt, unbuilder): _*)
-      }
-
-    implicit val resultLListIso: IsoLList.Aux[Result, Seq[Container] :*: ListMap[String, String] :*: LNil] =
-      LList.iso(
-        { case Result(allContainers, versionMap) =>
-          ("allContainers" -> allContainers) :*: ("versionMap" -> versionMap) :*: LNil
-        },
-        { case (_, allContainers) :*: (_, versionMap) :*: LNil =>
-          Result(allContainers, versionMap)
-        }
-      )
-  }
 
   private def versions = Versions.loadVersions()
 

--- a/project/Setting.scala
+++ b/project/Setting.scala
@@ -1,7 +1,3 @@
-import sjsonnew.BasicJsonProtocol.{BooleanJsonFormat, StringJsonFormat, seqFormat}
-import sjsonnew.{:*:, IsoLList, LList, LNil}
-
-
 case class Setting(name: String, flagSegments: Seq[FlagSegment], description: String, isDeprecated: Boolean = false) {
   def mergeLiteralSegments = copy(flagSegments = flagSegments.foldRight(List.empty[FlagSegment]) {
     case (FlagSegment.Literal(text1), FlagSegment.Literal(text2) :: segments) =>
@@ -9,20 +5,4 @@ case class Setting(name: String, flagSegments: Seq[FlagSegment], description: St
     case (segment, segments)                                                  =>
       segment :: segments
   })
-}
-
-object Setting {
-  implicit val settingLListIso: IsoLList.Aux[Setting, String :*: Seq[FlagSegment] :*: String :*: Boolean :*: LNil] =
-    LList.iso(
-      { case Setting(name, flagSegments, description, isDeprecated) =>
-        ("name"           -> name) :*:
-          ("flagSegments" -> flagSegments) :*:
-          ("description"  -> description) :*:
-          ("isDeprecated" -> isDeprecated) :*:
-          LNil
-      },
-      { case (_, name) :*: (_, flagSegments) :*: (_, description) :*: (_, isDeprecated) :*: LNil =>
-        Setting(name, flagSegments, description, isDeprecated)
-      }
-    )
 }


### PR DESCRIPTION
Drop the IsoLList/JsonFormat instances on Container, Setting, and
Generator.Result, plus the associated sjsonnew imports. These were
needed when the build cached the rich Generator.Result, but the
cache value type was narrowed to Generator.Outputs in 2021 (commit
d0168b3 "Factor out getOutputs sbt task"), leaving these formats
unused since then.
