### PR TITLE
refactor: simplify generate and move cache to per-(version,flag) granularity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,16 +6,14 @@ The primary build definition lives in `build.sbt`, with release automation in `c
 ## Build, Test, and Development Commands
 - `sbt compile` – compile the generator and any generated sources.
 - `sbt updateVersions` / `sbt updateVersionsDryRun` – query Maven Central and extend the top-most ranges in `versions.yaml` for new patch releases (dry-run mode reports what would change without writing).
-- `sbt downloadScalaCompilerJars` – prefetch all compiler artifacts defined in `versions.yaml`; run this once whenever you update the version list.
-- `sbt getOutputs` – fetch and cache `scalac -help` outputs for the configured versions; use to refresh local caches.
-- `sbt generate` – regenerate option traits under `target/scala-*/src_managed/io/github/nafg/scalacoptions`.
+- `sbt generate` – regenerate option traits under `target/scala-*/src_managed/io/github/nafg/scalacoptions`. Compiler JARs are fetched lazily and `scalac -help` outputs are cached per `(version, flag)` inside `runScalacFn`, so subsequent runs only re-execute pairs that haven't been seen.
 - `sbt test` – run the test suite (currently `src/test/scala/io/github/nafg/scalacoptions/CompilationTests.scala`); use `+test` to run across the cross-build (Scala 2.12 / 2.13 / 3.3).
 
 ## Coding Style & Naming Conventions
 Follow the `.scalafmt.conf` preset (IntelliJ style, 120-column limit, two-space indents). Format changes with a scalafmt-enabled editor or CLI before committing. Stick to CamelCase for Scala classes/traits (`Container`, `FlagSegment`) and lowerCamelCase for vals/defs. When adding options, mirror the existing naming in `project/Setting.scala` so generated identifiers remain predictable.
 
 ## Testing Guidelines
-When introducing logic changes, add focused unit tests under `src/test/scala` using ScalaTest or MUnit (your choice, but keep the dependency lightweight). Name test files after the type under test, e.g., `GeneratorSpec.scala`. If you touch version parsing or flag handling, run `sbt getOutputs` followed by a regeneration and review the diff to ensure no unintended option churn.
+When introducing logic changes, add focused unit tests under `src/test/scala` using ScalaTest or MUnit (your choice, but keep the dependency lightweight). Name test files after the type under test, e.g., `GeneratorSpec.scala`. If you touch version parsing or flag handling, run `sbt generate` and review the diff to ensure no unintended option churn — the per-`(version, flag)` cache will reuse prior `scalac -help` outputs automatically.
 
 ## Commit & Pull Request Guidelines
 Commit messages should be concise and imperative (“Add Scala 3.3.2 descriptors”). PRs should describe the motivation, list key changes, and note any manual steps (such as running `sbt generate`). Link related issues and include before/after snippets when updating generated sources. For dependency bumps or version additions, mention the impacted Scala releases and any follow-up tasks so maintainers can coordinate downstream publishing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,9 +13,7 @@ The library itself cross-builds on Scala 2.12 / 2.13 / 3.3 (see `build.sbt` for 
 - `sbt compile` - Compile the generator and generated sources
 - `sbt updateVersions` - Query Maven Central and extend top-most ranges in versions.yaml for new patch releases
 - `sbt updateVersionsDryRun` - Same as above but does not modify the file
-- `sbt downloadScalaCompilerJars` - Prefetch all compiler artifacts from versions.yaml (run once after updating version list)
-- `sbt getOutputs` - Fetch and cache `scalac -help` outputs for all configured versions
-- `sbt generate` - Regenerate option traits under `target/scala-*/src_managed/io/github/nafg/scalacoptions`
+- `sbt generate` - Regenerate option traits under `target/scala-*/src_managed/io/github/nafg/scalacoptions` (fetches compilers and runs `scalac -help` lazily; results are cached per `(version, flag)`)
 - `sbt test` - Run tests
 
 ## Architecture
@@ -51,7 +49,7 @@ Build-definition Scala code lives under `project/` so sbt can use it from build 
 - **project/Generator.scala** - Main orchestration logic
 - **project/Versions.scala** - Parses versions.yaml and models version hierarchy
 - **project/VersionUpdater.scala** - Queries Maven Central and extends top-most ranges in versions.yaml when new patch releases appear
-- **project/GetHelpString.scala** - Downloads compiler JARs and extracts help output
+- **launcher/** subproject (`launcher/src/main/scala/.../launcher/Scalac.scala`) - Standalone main that fetches a compiler via Coursier and runs it in a forked JVM, capturing combined stdout+stderr. Wired into the build via the `runScalacFn` task.
 - **project/FastParseParser.scala** - Parses scalac help text into Setting objects
 - **project/CodeGen.scala** - Generates trait method definitions
 - **project/Container.scala**, **project/Setting.scala**, **project/FlagSegment.scala** - Core data models
@@ -71,16 +69,14 @@ Generated traits go to `target/.../src_managed/` and are included as managed sou
 ### Adding a New Scala Version
 
 1. Update `versions.yaml` with the new version range and help flags. For new patches in an existing major series, prefer `sbt updateVersionsDryRun` / `sbt updateVersions` to extend the top-most range automatically. New major series (e.g., 3.8) still need to be added by hand.
-2. Run `sbt downloadScalaCompilerJars` to fetch the new compiler
-3. Run `sbt generate` to regenerate option traits
-4. Review the git diff to verify new options were added correctly
+2. Run `sbt generate` to regenerate option traits (compiler JARs are fetched lazily by the launcher)
+3. Review the git diff to verify new options were added correctly
 
 ### Modifying Option Parsing
 
 When changing parser logic in `project/FastParseParser.scala`:
-1. Run `sbt getOutputs` to refresh cached outputs (if needed)
-2. Run `sbt generate` to regenerate with new parsing logic
-3. Review generated output for correctness
+1. Run `sbt generate` to regenerate with new parsing logic. The `(version, flag)` cache reuses prior `scalac -help` outputs, so you only re-run scalac for entries that haven't been seen.
+2. Review generated output for correctness
 
 ### Adding Custom Option Overrides
 

--- a/build.sbt
+++ b/build.sbt
@@ -25,14 +25,12 @@ useReadableConsoleGit
 def runVersionUpdater(log: sbt.util.Logger, dryRun: Boolean): Unit =
   log.info(Await.result(new VersionUpdater().run(dryRun = dryRun), 5.minutes))
 
-val updateVersions            = taskKey[Unit]("Update versions.yaml with latest Scala releases from Maven Central")
-val updateVersionsDryRun      = taskKey[Unit]("Check for new Scala versions without modifying versions.yaml")
-val downloadScalaCompilerJars = taskKey[Unit]("Download all scala compiler jars")
-val getOutputs                = taskKey[Generator.Outputs]("Run all scala compilers with help flags & get the outputs")
-val runScalacFn               = taskKey[(Versions.Minor, String) => String](
+val updateVersions       = taskKey[Unit]("Update versions.yaml with latest Scala releases from Maven Central")
+val updateVersionsDryRun = taskKey[Unit]("Check for new Scala versions without modifying versions.yaml")
+val runScalacFn          = taskKey[(Versions.Minor, String) => String](
   "Function that runs scalac for a given version + flag, returning combined stdout+stderr"
 )
-val generate                  = inputKey[Seq[File]]("Generate code. Optionally pass one or more Scala versions.")
+val generate             = inputKey[Seq[File]]("Generate code. Optionally pass one or more Scala versions.")
 
 def selectScalaVersions(args: Seq[String]): Seq[Versions.Minor] = {
   val requested = args.flatMap(_.split(",")).filter(_.nonEmpty)
@@ -98,26 +96,18 @@ lazy val launcher =
         val scalaRunner   = (Compile / runner).value
         val mainClassName = (Compile / mainClass).value.getOrElse(sys.error("No main class found in scalacRunner"))
 
-        val cacheStore = streams.value.cacheStoreFactory.make("scalac-options-output.json")
-        val cached     =
-          Cache.cached[(Versions.Minor, String), String](cacheStore) { case (version, flag) =>
-            blocking {
-              val tempFile = os.temp(prefix = "scalac-out", suffix = ".txt")
-              try {
-                scalaRunner.run(mainClassName, cp, Seq(tempFile.toString(), version.versionString, flag), log).get
-                os.read(tempFile)
-              } finally
-                os.remove(tempFile)
-            }
+        { (version, flag) =>
+          blocking {
+            val tempFile = os.temp(prefix = "scalac-out", suffix = ".txt")
+            try {
+              scalaRunner.run(mainClassName, cp, Seq(tempFile.toString(), version.versionString, flag), log).get
+              os.read(tempFile)
+            } finally
+              os.remove(tempFile)
           }
-
-        Function.untupled(cached)
+        }
       }
     )
-
-def writeCachedOutputs(cacheDirectory: File, outputs: Generator.Outputs): Unit =
-  for ((version, pages) <- outputs; (flag, output) <- pages)
-    IO.write(cacheDirectory / version.versionString / (flag + ".txt"), output)
 
 lazy val library = (project in file("."))
   .dependsOn(launcher % Test)
@@ -130,52 +120,26 @@ lazy val library = (project in file("."))
     updateVersions       := runVersionUpdater(streams.value.log, dryRun = false),
     updateVersionsDryRun := runVersionUpdater(streams.value.log, dryRun = true),
 
-    downloadScalaCompilerJars := {
-      streams.value.log.info("Downloading all scala compiler jars...")
-      Await.result(Generator.prefetch, Duration.Inf)
-      streams.value.log.info("Finished downloading all scala compiler jars...")
-    },
-
-    getOutputs := {
-      val selectedVersions = selectScalaVersions(Nil)
-      downloadScalaCompilerJars.value
-
-      val cacheStore  = streams.value.cacheStoreFactory.make("scalac-options-outputs")
-      val runLauncher = (launcher / runScalacFn).value
-      val runCached   =
-        Cache.cached[Seq[Versions.Minor], Generator.Outputs](cacheStore)(Generator.getOutputs(_)(runLauncher))
-
-      val outputs = runCached(selectedVersions)
-
-      writeCachedOutputs(streams.value.cacheDirectory, outputs)
-
-      outputs
-    },
-
     generate := Def.inputTaskDyn {
       val args             = spaceDelimited("<scala-version>").parsed
       val selectedVersions = selectScalaVersions(args)
 
-      if (args.isEmpty)
-        Def.task {
-          writeGeneratedCode((Compile / sourceManaged).value, getOutputs.value)
-        }
-      else
-        Def.task {
-          streams.value.log.info(
-            s"Downloading scala compiler jars for ${selectedVersions.map(_.versionString).mkString(", ")}..."
-          )
-          Await.result(Generator.prefetch(selectedVersions), Duration.Inf)
-          streams.value.log.info("Finished downloading scala compiler jars.")
+      Def.task {
+        val cacheStore  = streams.value.cacheStoreFactory.make("scalac-options-outputs")
+        val runLauncher = (launcher / runScalacFn).value
+        val runCached   =
+          Cache.cached[Seq[Versions.Minor], Generator.Outputs](cacheStore) { versions =>
+            streams.value.log.info(
+              s"Downloading scala compiler jars for ${versions.map(_.versionString).mkString(", ")}..."
+            )
+            val res = Generator.getOutputs(versions)(runLauncher)
+            streams.value.log.info("Finished downloading scala compiler jars.")
+            res
+          }
 
-          val cacheStore  = streams.value.cacheStoreFactory.make("scalac-options-outputs")
-          val runLauncher = (launcher / runScalacFn).value
-          val runCached   =
-            Cache.cached[Seq[Versions.Minor], Generator.Outputs](cacheStore)(Generator.getOutputs(_)(runLauncher))
-
-          val outputs = runCached(selectedVersions)
-          writeGeneratedCode((Compile / sourceManaged).value, outputs)
-        }
+        val outputs = runCached(selectedVersions)
+        writeGeneratedCode((Compile / sourceManaged).value, outputs)
+      }
     }.evaluated,
 
     Compile / sourceGenerators += generate.toTask("").taskValue,

--- a/build.sbt
+++ b/build.sbt
@@ -96,15 +96,24 @@ lazy val launcher =
         val scalaRunner   = (Compile / runner).value
         val mainClassName = (Compile / mainClass).value.getOrElse(sys.error("No main class found in scalacRunner"))
 
+        val baseCacheStoreFactory = streams.value.cacheStoreFactory
+
         { (version, flag) =>
-          blocking {
-            val tempFile = os.temp(prefix = "scalac-out", suffix = ".txt")
-            try {
-              scalaRunner.run(mainClassName, cp, Seq(tempFile.toString(), version.versionString, flag), log).get
-              os.read(tempFile)
-            } finally
-              os.remove(tempFile)
-          }
+          val cacheStoreFactory = baseCacheStoreFactory.sub(version.versionString).sub(flag)
+          val cacheStore        = cacheStoreFactory.make("scalac-options-output.json")
+          val cached            =
+            Cache.cached[Unit, String](cacheStore) { _ =>
+              blocking {
+                val tempFile = os.temp(prefix = "scalac-out", suffix = ".txt")
+                try {
+                  scalaRunner.run(mainClassName, cp, Seq(tempFile.toString(), version.versionString, flag), log).get
+                  os.read(tempFile)
+                } finally
+                  os.remove(tempFile)
+              }
+            }
+
+          cached(())
         }
       }
     )
@@ -125,19 +134,11 @@ lazy val library = (project in file("."))
       val selectedVersions = selectScalaVersions(args)
 
       Def.task {
-        val cacheStore  = streams.value.cacheStoreFactory.make("scalac-options-outputs")
-        val runLauncher = (launcher / runScalacFn).value
-        val runCached   =
-          Cache.cached[Seq[Versions.Minor], Generator.Outputs](cacheStore) { versions =>
-            streams.value.log.info(
-              s"Downloading scala compiler jars for ${versions.map(_.versionString).mkString(", ")}..."
-            )
-            val res = Generator.getOutputs(versions)(runLauncher)
-            streams.value.log.info("Finished downloading scala compiler jars.")
-            res
-          }
+        val versionsString = selectedVersions.map(_.versionString).mkString(", ")
+        streams.value.log.info(s"Getting compiler help texts for $versionsString...")
+        val outputs        = Generator.getOutputs(selectedVersions)((launcher / runScalacFn).value)
+        streams.value.log.info("Finished collecting compiler help texts.")
 
-        val outputs = runCached(selectedVersions)
         writeGeneratedCode((Compile / sourceManaged).value, outputs)
       }
     }.evaluated,

--- a/project/FlagSegment.scala
+++ b/project/FlagSegment.scala
@@ -1,5 +1,3 @@
-import sjsonnew.BasicJsonProtocol.{flatUnionFormat2, isoStringFormat}
-import sjsonnew.{IsoString, JsonFormat}
 import zio.json.{DeriveJsonCodec, JsonCodec, jsonHint}
 
 
@@ -11,13 +9,6 @@ object FlagSegment {
 
   @jsonHint("param")
   case class Parameter(name: String) extends FlagSegment
-
-  implicit val literalIsoString: IsoString[Literal]       =
-    IsoString.iso(_.text, Literal)
-  implicit val parameterIsoString: IsoString[Parameter]   =
-    IsoString.iso(_.name, Parameter)
-  implicit val flagSegmentFormat: JsonFormat[FlagSegment] =
-    flatUnionFormat2[FlagSegment, Literal, Parameter]
 
   implicit val literalCodec: JsonCodec[Literal]     = JsonCodec.string.transform(Literal(_), _.text)
   implicit val parameterCodec: JsonCodec[Parameter] = JsonCodec.string.transform(Parameter(_), _.name)

--- a/project/Generator.scala
+++ b/project/Generator.scala
@@ -1,6 +1,3 @@
-import coursier.core.{Module, ModuleName, Organization}
-import coursier.{Dependency, Fetch}
-
 import scala.collection.immutable.{ListMap, SortedMap}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
@@ -64,32 +61,6 @@ object Generator {
       )
 
   case class Result(allContainers: Seq[Container], versionMap: ListMap[String, String])
-
-  private def versions = Versions.loadVersions()
-
-  private def dependency(version: Versions.Minor) =
-    Dependency(
-      Module(
-        Organization("org.scala-lang"),
-        ModuleName(
-          version match {
-            case Versions.Minor(2, _, _, _, _, _)       => "scala-compiler"
-            case Versions.Minor(3, _, _, Some(_), _, _) => s"scala3-compiler_${version.versionString}"
-            case Versions.Minor(3, _, _, None, _, _)    => "scala3-compiler_3"
-            case _                                      => sys.error("Unsupported version: " + version)
-          }
-        ),
-        Map.empty
-      ),
-      version.versionString
-    )
-
-  def prefetch: Future[Unit] = prefetch(versions.flatMap(_.allMinors))
-
-  def prefetch(versions: Seq[Versions.Minor]) =
-    Fetch()
-      .addDependencies(versions.map(dependency)*)
-      .future().map(_ => ())
 
   def getOutputs(versions: Seq[Versions.Minor])(runScalac: (Versions.Minor, String) => String) = Await.result(
     Future.traverse(versions) { version =>

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -3,8 +3,6 @@ import scala.collection.immutable.SortedMap
 import Versions.VersionConfig.PatchRange
 import sbt.io.IO
 import sbt.io.syntax.file
-import sjsonnew.BasicJsonProtocol.*
-import sjsonnew.{:*:, IsoLList, LList, LNil}
 import zio.json.*
 import zio.json.yaml.*
 
@@ -25,23 +23,6 @@ object Versions {
   }
 
   object Minor {
-    implicit val minorLListIso: IsoLList.Aux[
-      Minor,
-      (Int, Int, Int) :*: Option[(String, Int)] :*: Seq[String] :*: Map[String, Seq[FlagSegment]] :*: LNil
-    ] =
-      LList.iso(
-        { case Minor(epoch, major, minor, prerelease, helpFlags, settings) =>
-          "version"      -> (epoch, major, minor) :*:
-            "prerelease" -> prerelease :*:
-            "helpFlags"  -> helpFlags :*:
-            "settings"   -> settings :*:
-            LNil
-        },
-        { case (_, (epoch, major, minor)) :*: (_, prerelease) :*: (_, helpFlags) :*: (_, settings) :*: LNil =>
-          Minor(epoch, major, minor, prerelease, helpFlags, settings)
-        }
-      )
-
     implicit val ordering: Ordering[Minor] =
       Ordering.by { case Minor(epoch, major, minor, prerelease, _, _) =>
         (epoch, major, minor, prerelease.getOrElse("" -> 0))


### PR DESCRIPTION
## Summary

- Remove the `downloadScalaCompilerJars` and `getOutputs` prefetch tasks plus the Coursier-based prefetch logic in `Generator.scala`. `generate` is now a single unified path regardless of arguments.
- Replace the coarse library-level cache (keyed by the full list of Scala versions) with a fine-grained cache inside `runScalacFn`, keyed per `(version, flag)` pair, so incremental runs only re-execute combinations that have never been seen.
- Drop the sjsonnew `IsoString`/`IsoLList` instances for `FlagSegment` and `Versions.Minor` since they existed solely to support the old cache's serialization format.

## Test plan

- [ ] `sbt compile` — builds cleanly
- [ ] `sbt generate` produces identical output to master
- [ ] `sbt generate` a second time hits the cache for all (version, flag) pairs
- [ ] `sbt generate 2.13.18` (subset) reuses the cache from the previous full run

🤖 Generated with [Claude Code](https://claude.com/claude-code)