### PR TITLE
fix(parser): handle Choices block without colon (Scala 3.1.3..3.2.2)

### DIFF
--- a/project/FastParseParser.scala
+++ b/project/FastParseParser.scala
@@ -76,7 +76,7 @@ object FastParseParser {
     private def descriptionEnd[_: P]: P[Unit] = P(End | "\n" ~ !continuationLineStart)
 
     private def choicesMarker[_: P]: P[Unit] =
-      P("Choices" ~ Text.spaces ~ ":" ~ Text.spaces ~ ("\n" ~ continuationLineStart).? ~ Text.spaces)
+      P("Choices" ~ Text.spaces ~ ":".? ~ Text.spaces ~ ("\n" ~ continuationLineStart).? ~ Text.spaces)
 
     private def choiceBlockBody[_: P]: P[Unit] =
       P((!descriptionEnd ~ AnyChar).rep)

--- a/src/test/scala/io/github/nafg/scalacoptions/OptionsAcceptanceSpec.scala
+++ b/src/test/scala/io/github/nafg/scalacoptions/OptionsAcceptanceSpec.scala
@@ -79,6 +79,21 @@ class OptionsAcceptanceSpec extends munit.FunSuite {
     }
   }
 
+  test("-java-output-version") {
+    assertAccepted { version =>
+      ScalacOptions.all(version)(
+        (opts: options.V3_1_2_+) => opts.javaOutputVersion("8"),
+        (opts: options.V3_2) => opts.javaOutputVersion("8"),
+        (opts: options.V3_3) => opts.javaOutputVersion("8"),
+        (opts: options.V3_4) => opts.javaOutputVersion("8"),
+        (opts: options.V3_5) => opts.javaOutputVersion("8"),
+        (opts: options.V3_6) => opts.javaOutputVersion("8"),
+        (opts: options.V3_7) => opts.javaOutputVersion("8"),
+        (opts: options.V3_8) => opts.javaOutputVersion("8")
+      )
+    }
+  }
+
   test("-Wconf") {
     assertAccepted { version =>
       ScalacOptions.all(version)(WarningsConfig(Filter.Category(Category.`lint-byname-implicit`).silent))


### PR DESCRIPTION
## Summary

Scala 3.1.3 through 3.2.2 emit `Choices` blocks in `-help` output **without** the trailing colon (\`Choices 8, 9, ...\`), unlike 3.0..3.1.2 (\`Choices: ...\`) and 3.3+ (\`Choices : ...\`). The parser only matched the colon-bearing forms, causing `descriptionWithChoices` to fall through to `plainDescription` and `Sections.settingLine` to skip parameter synthesis. The result: \`def javaOutputVersion = List("-java-output-version")\` (nullary) was generated on \`V3_1_3_+\` and \`V3_2\`, even though scalac requires an argument.

This PR is shaped as a TDD pair:
- **Commit 1 (red)**: failing test asserting \`javaOutputVersion(_: String)\` is reachable from \`V3_1_2_+\` and \`V3_2\`.
- **Commit 2 (green)**: parser fix in \`FastParseParser.choicesMarker\` + regenerated traits.

After the fix, \`javaOutputVersion(choice)\` has consistent segments across V3_1_2..V3_8 and lifts onto the \`V3_1_2_+\` range trait.

\`-release\` is intentionally **not** added on V3.1.2+. Per [Scala 3.1.2 release notes](https://www.scala-lang.org/blog/2022/04/12/scala-3.1.2-released.html), \`-release\` is a permanent alias for \`-java-output-version\` but only the canonical name appears in help; the DSL principle here is to trust help output.

## Test plan

- [ ] First commit: CI fails with \`value javaOutputVersion is not a member of … V3_1_2_+\` and \`type mismatch; … required: Int\` on V3_2.
- [ ] Second commit: CI passes, generated diff shows V3_1_3_+ and V3_2 with parameterized \`javaOutputVersion(choice: String)\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)