### PR TITLE
docs: drop manual-task instructions for auto-run sbt tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ The primary build definition lives in `build.sbt`, with release automation in `c
 Follow the `.scalafmt.conf` preset (IntelliJ style, 120-column limit, two-space indents). Format changes with a scalafmt-enabled editor or CLI before committing. Stick to CamelCase for Scala classes/traits (`Container`, `FlagSegment`) and lowerCamelCase for vals/defs. When adding options, mirror the existing naming in `project/Setting.scala` so generated identifiers remain predictable.
 
 ## Testing Guidelines
-When introducing logic changes, add focused unit tests under `src/test/scala` using ScalaTest or MUnit (your choice, but keep the dependency lightweight). Name test files after the type under test, e.g., `GeneratorSpec.scala`. If you touch version parsing or flag handling, recompile and review the diff in `target/scala-*/src_managed/` to ensure no unintended option churn.
+When introducing logic changes, add focused unit tests under `src/test/scala` using MUnit, which is the test framework currently configured for this repository. Name test files after the type under test, e.g., `GeneratorSpec.scala`. If you touch version parsing or flag handling, recompile and review the diff in `target/scala-*/src_managed/` to ensure no unintended option churn.
 
 ## Commit & Pull Request Guidelines
 Commit messages should be concise and imperative (“Add Scala 3.3.2 descriptors”). PRs should describe the motivation and list key changes. Link related issues and include before/after snippets when updating generated sources. For dependency bumps or version additions, mention the impacted Scala releases and any follow-up tasks so maintainers can coordinate downstream publishing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,16 +4,16 @@
 The primary build definition lives in `build.sbt`, with release automation in `ci.sbt` and Scala release metadata in `versions.yaml`. Build-definition Scala code, including the generator invoked by sbt tasks, resides under `project/` (e.g., `project/Generator.scala`, `project/Versions.scala`, `project/VersionUpdater.scala`); `project/*.sbt` configures that build definition's own build. Hand-written runtime library code lives under `src/main/scala`, while generated option traits are emitted under `target/scala-*/src_managed`.
 
 ## Build, Test, and Development Commands
-- `sbt compile` – compile the generator and any generated sources.
-- `sbt updateVersions` / `sbt updateVersionsDryRun` – query Maven Central and extend the top-most ranges in `versions.yaml` for new patch releases (dry-run mode reports what would change without writing).
-- `sbt generate` – regenerate option traits under `target/scala-*/src_managed/io/github/nafg/scalacoptions`. Compiler JARs are fetched lazily and `scalac -help` outputs are cached per `(version, flag)` inside `runScalacFn`, so subsequent runs only re-execute pairs that haven't been seen.
-- `sbt test` – run the test suite (currently `src/test/scala/io/github/nafg/scalacoptions/CompilationTests.scala`); use `+test` to run across the cross-build (Scala 2.12 / 2.13 / 3.3).
+- `sbt compile` – compile the library; option traits are produced as a sourceGenerator step.
+- `sbt test` – run the test suite (currently `src/test/scala/io/github/nafg/scalacoptions/`); use `+test` to run across the cross-build (Scala 2.12 / 2.13 / 3.3).
+
+`updateVersions` and `generate` run automatically (via GitHub Actions or sourceGenerator) and shouldn't be invoked by hand.
 
 ## Coding Style & Naming Conventions
 Follow the `.scalafmt.conf` preset (IntelliJ style, 120-column limit, two-space indents). Format changes with a scalafmt-enabled editor or CLI before committing. Stick to CamelCase for Scala classes/traits (`Container`, `FlagSegment`) and lowerCamelCase for vals/defs. When adding options, mirror the existing naming in `project/Setting.scala` so generated identifiers remain predictable.
 
 ## Testing Guidelines
-When introducing logic changes, add focused unit tests under `src/test/scala` using ScalaTest or MUnit (your choice, but keep the dependency lightweight). Name test files after the type under test, e.g., `GeneratorSpec.scala`. If you touch version parsing or flag handling, run `sbt generate` and review the diff to ensure no unintended option churn — the per-`(version, flag)` cache will reuse prior `scalac -help` outputs automatically.
+When introducing logic changes, add focused unit tests under `src/test/scala` using ScalaTest or MUnit (your choice, but keep the dependency lightweight). Name test files after the type under test, e.g., `GeneratorSpec.scala`. If you touch version parsing or flag handling, recompile and review the diff in `target/scala-*/src_managed/` to ensure no unintended option churn.
 
 ## Commit & Pull Request Guidelines
-Commit messages should be concise and imperative (“Add Scala 3.3.2 descriptors”). PRs should describe the motivation, list key changes, and note any manual steps (such as running `sbt generate`). Link related issues and include before/after snippets when updating generated sources. For dependency bumps or version additions, mention the impacted Scala releases and any follow-up tasks so maintainers can coordinate downstream publishing.
+Commit messages should be concise and imperative (“Add Scala 3.3.2 descriptors”). PRs should describe the motivation and list key changes. Link related issues and include before/after snippets when updating generated sources. For dependency bumps or version additions, mention the impacted Scala releases and any follow-up tasks so maintainers can coordinate downstream publishing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,11 +10,10 @@ The library itself cross-builds on Scala 2.12 / 2.13 / 3.3 (see `build.sbt` for 
 
 ## Build Commands
 
-- `sbt compile` - Compile the generator and generated sources
-- `sbt updateVersions` - Query Maven Central and extend top-most ranges in versions.yaml for new patch releases
-- `sbt updateVersionsDryRun` - Same as above but does not modify the file
-- `sbt generate` - Regenerate option traits under `target/scala-*/src_managed/io/github/nafg/scalacoptions` (fetches compilers and runs `scalac -help` lazily; results are cached per `(version, flag)`)
+- `sbt compile` - Compile the library (generated sources are produced as a sourceGenerator step)
 - `sbt test` - Run tests; `sbt +test` to cross-build against all Scala versions
+
+`updateVersions` (extends versions.yaml from Maven Central) and `generate` (the sourceGenerator) run automatically — via GitHub Actions or `sbt compile` — and shouldn't be invoked by hand.
 
 ## Architecture
 
@@ -66,17 +65,9 @@ Generated traits go to `target/.../src_managed/` and are included as managed sou
 
 ## Development Workflow
 
-### Adding a New Scala Version
-
-1. Update `versions.yaml` with the new version range and help flags. For new patches in an existing major series, prefer `sbt updateVersionsDryRun` / `sbt updateVersions` to extend the top-most range automatically. New major series (e.g., 3.8) still need to be added by hand.
-2. Run `sbt generate` to regenerate option traits (compiler JARs are fetched lazily by the launcher)
-3. Review the git diff to verify new options were added correctly
-
 ### Modifying Option Parsing
 
-When changing parser logic in `project/FastParseParser.scala`:
-1. Run `sbt generate` to regenerate with new parsing logic. The `(version, flag)` cache reuses prior `scalac -help` outputs, so you only re-run scalac for entries that haven't been seen.
-2. Review generated output for correctness
+When changing parser logic in `project/FastParseParser.scala`, the next `sbt compile` will re-run the sourceGenerator. The `(version, flag)` cache reuses prior `scalac -help` outputs, so you only re-run scalac for entries that haven't been seen. Review the regenerated traits under `target/scala-*/src_managed/` for correctness.
 
 ### Adding Custom Option Overrides
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,8 @@ The library itself cross-builds on Scala 2.12 / 2.13 / 3.3 (see `build.sbt` for 
 - `sbt compile` - Compile the library (generated sources are produced as a sourceGenerator step)
 - `sbt test` - Run tests; `sbt +test` to cross-build against all Scala versions
 
-`updateVersions` (extends versions.yaml from Maven Central) and `generate` (the sourceGenerator) run automatically — via GitHub Actions or `sbt compile` — and shouldn't be invoked by hand.
+`generate` runs automatically as a sourceGenerator step when you run `sbt compile`.
+`updateVersions` extends `versions.yaml` from Maven Central and is run by the `update-versions.yml` workflow, or manually via `sbt updateVersions`.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Trim `## Build Commands` / `## Build, Test, and Development Commands` to the two commands a contributor actually invokes (`sbt compile`, `sbt test`).
- Remove the "Adding a New Scala Version" walkthrough; the `update-versions.yml` workflow handles it.
- Drop `sbt generate` from "Modifying Option Parsing", Testing Guidelines, and Commit & PR Guidelines — it's a sourceGenerator, not a manual step.

## Test plan
- [ ] `sbt compile` still works
- [ ] Render both files and confirm headings/structure are intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)