### PR TITLE
fix(build): publish as scalac-options, not library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -121,6 +121,7 @@ lazy val launcher =
 lazy val library = (project in file("."))
   .dependsOn(launcher % Test)
   .settings(
+    name := "scalac-options",
     libraryDependencies ++= Seq(
       ("io.get-coursier" %% "coursier-core" % "2.1.24").cross(CrossVersion.for3Use2_13),
       "org.scalameta"    %% "munit"         % "1.3.0" % Test


### PR DESCRIPTION
## Summary

The launcher subproject extraction in commit \`refactor(build): extract scalac execution into launcher subproject\` introduced \`lazy val library = (project in file("."))\` with no \`name\` setting. As a result v0.5.1 was published under the sbt project id — \`library_2.12\`, \`library_2.13\`, \`library_3\` — instead of \`scalac-options_*\`, breaking every existing consumer.

Set \`name := "scalac-options"\` on the root project to restore the published artifact id. v0.5.1 itself is unsalvageable (Maven Central is immutable), so the next tag should be 0.5.2.

## Test plan

- [ ] CI green
- [ ] After release, \`io/github/nafg/scalac-options/scalac-options_2.12/0.5.2/\` exists on Maven Central