### PR TITLE
chore: bump scalac-options to 0.5.2

### DIFF
--- a/project/build-build.sbt
+++ b/project/build-build.sbt
@@ -4,7 +4,7 @@ libraryDependencies += "com.lihaoyi"                   %% "os-lib"         % "0.
 libraryDependencies += "com.lihaoyi"                   %% "pprint"         % "0.9.6"
 libraryDependencies += "io.get-coursier"               %% "coursier"       % "2.1.24"
 libraryDependencies += "dev.zio"                       %% "zio-json-yaml"  % "0.9.2"
-libraryDependencies += "io.github.nafg.scalac-options" %% "scalac-options" % "0.5.0"
+libraryDependencies += "io.github.nafg.scalac-options" %% "scalac-options" % "0.5.2"
 
 scalacOptions += "-deprecation"
 scalacOptions += "-Xlint:_"


### PR DESCRIPTION
Bump the meta-build's \`scalac-options\` dependency from 0.5.0 → 0.5.2.

Switching the build's own \`-release 8\` to the typed DSL is deferred to a follow-up PR that depends on adding cross-major minor-version range traits (e.g. \`V3_2_+\` covering 3.2.0..<4.0.0).