### PR TITLE
feat(generator): add cross-major minor-range traits (V3_2_+, etc.)

### DIFF
--- a/project/Generator.scala
+++ b/project/Generator.scala
@@ -29,7 +29,7 @@ object Generator {
         Ordering.comparatorToOrdering(String.CASE_INSENSITIVE_ORDER)
       )
 
-  private def common(settingsGroups: Seq[Seq[Setting]]) =
+  private def common(settingsGroups: Seq[Seq[Setting]]): Seq[Setting] =
     settingsGroups
       .map(_.map(setting => setting.name -> setting).toMap)
       .reduceLeft { (settings1, settings2) =>
@@ -86,34 +86,55 @@ object Generator {
         version -> settings
       }
 
-    val groupedEpoch = allSettings.groupBy(_._1.epoch)
-    val groupedMajor = allSettings.groupBy(t => (t._1.epoch, t._1.major))
-    val groupedRange =
+    val groupedEpoch      = allSettings.groupBy(_._1.epoch)
+    val groupedMajor      = allSettings.groupBy(t => (t._1.epoch, t._1.major))
+    val groupedMinorRange =
+      SortedMap.empty[(Int, Int), Seq[(Versions.Minor, Seq[Setting])]] ++
+        groupedEpoch.flatMap { case (epoch, settings) =>
+          val byMajor = settings.groupBy(_._1.major).toSeq.sortBy(_._1)
+          byMajor.tails.filterNot(_.isEmpty).map { tail =>
+            (epoch, tail.head._1) -> tail.flatMap(_._2)
+          }
+        }
+    val groupedRange      =
       SortedMap.empty[Versions.Minor, Seq[(Versions.Minor, Seq[Setting])]] ++
         groupedMajor.flatMap { case (_, settings) =>
           settings.tails.filterNot(_.isEmpty).map(t => t.head._1 -> t)
         }
 
-    val commonAll   = common(allSettings.map(_._2))
-    val commonEpoch = groupedEpoch.mapValues(settings => common(settings.map(_._2)))
-    val commonMajor = groupedMajor.mapValues(settings => common(settings.map(_._2)))
-    val commonRange = groupedRange.mapValues(settings => common(settings.map(_._2)))
+    def common(versionGroup: Seq[(Versions.Minor, Seq[Setting])]): Seq[Setting] =
+      Generator.common(versionGroup.map(_._2))
+
+    val commonAll        = common(allSettings)
+    val commonEpoch      = groupedEpoch.mapValues(common)
+    val commonMinorRange = groupedMinorRange.mapValues(common)
+    val commonMajor      = groupedMajor.mapValues(common)
+    val commonRange      = groupedRange.mapValues(common)
+
+    def printCommonCounts[K](group: Iterable[(K, Seq[Setting])])(show: K => String): Unit =
+      for ((k, s) <- group) println(s"${show(k)}: ${s.length} common settings")
 
     println(s"All: ${commonAll.length} common settings")
-    for ((v, s) <- commonEpoch) println(s"$v: ${s.length} common settings")
-    for (((e, m), s) <- commonMajor)
-      println(s"$e.$m: ${s.length} common settings")
-    for ((v, s) <- commonRange)
-      println(s"${v.versionString}+ ${s.length} common settings")
+    printCommonCounts(commonEpoch)(_.toString)
+    printCommonCounts(commonMinorRange) { case (e, m) => s"$e.$m+" }
+    printCommonCounts(commonMajor) { case (e, m) => s"$e.$m" }
+    printCommonCounts(commonRange)(v => s"${v.versionString}+")
 
-    val commonContainer    =
+    val commonContainer      =
       Container("Common", None, commonAll, isConcrete = false)
-    val epochContainers    = commonEpoch.transform { (epoch, settings) =>
+    val epochContainers      = commonEpoch.transform { (epoch, settings) =>
       Container(s"V$epoch", Some(commonContainer), settings, isConcrete = false)
     }
-    val majorContainers    = commonMajor.transform {
+    val minorRangeContainers =
+      commonMinorRange.foldLeft(SortedMap.empty[(Int, Int), Container]) {
+        case (map, ((epoch, major), settings)) =>
+          val parent = map.getOrElse((epoch, major - 1), epochContainers(epoch))
+          val name   = s"V${epoch}_${major}_+"
+          map + ((epoch, major) -> Container(name, Some(parent), settings, isConcrete = false))
+      }
+    val majorContainers      = commonMajor.transform {
       case ((epoch, major), settings) =>
-        val parent = epochContainers(epoch)
+        val parent = minorRangeContainers((epoch, major))
         Container(
           s"V${epoch}_$major",
           Some(parent),
@@ -121,7 +142,7 @@ object Generator {
           isConcrete = false
         )
     }
-    val rangeContainers    =
+    val rangeContainers      =
       commonRange.foldLeft(Map.empty[Versions.Minor, Container]) {
         case (map, (version @ Versions.Minor(epoch, major, minor, prerelease, _, _), settings)) =>
           val parent =
@@ -135,7 +156,7 @@ object Generator {
             s"V${epoch}_${major}_$minor" + version.prereleaseString.fold("")("_" + _) + "_+"
           map + (version -> Container(name, Some(parent), settings, isConcrete = false))
       }
-    val concreteContainers = ListMap(allSettings*).transform {
+    val concreteContainers   = ListMap(allSettings*).transform {
       case (version @ Versions.Minor(epoch, major, minor, _, _, _), settings) =>
         val parent = rangeContainers(version)
         val name   = s"V${epoch}_${major}_$minor" + version.prereleaseString.fold("")("_" + _)
@@ -146,6 +167,7 @@ object Generator {
       allContainers =
         List(commonContainer) ++
           epochContainers.values ++
+          minorRangeContainers.values ++
           majorContainers.values ++
           rangeContainers.values ++
           concreteContainers.values,

--- a/src/test/scala/io/github/nafg/scalacoptions/OptionsAcceptanceSpec.scala
+++ b/src/test/scala/io/github/nafg/scalacoptions/OptionsAcceptanceSpec.scala
@@ -92,13 +92,7 @@ class OptionsAcceptanceSpec extends munit.FunSuite {
     assertAccepted { version =>
       ScalacOptions.all(version)(
         (opts: options.V3_1_2_+) => opts.javaOutputVersion("8"),
-        (opts: options.V3_2) => opts.javaOutputVersion("8"),
-        (opts: options.V3_3) => opts.javaOutputVersion("8"),
-        (opts: options.V3_4) => opts.javaOutputVersion("8"),
-        (opts: options.V3_5) => opts.javaOutputVersion("8"),
-        (opts: options.V3_6) => opts.javaOutputVersion("8"),
-        (opts: options.V3_7) => opts.javaOutputVersion("8"),
-        (opts: options.V3_8) => opts.javaOutputVersion("8")
+        (opts: options.V3_2_+) => opts.javaOutputVersion("8")
       )
     }
   }

--- a/src/test/scala/io/github/nafg/scalacoptions/OptionsSpec.scala
+++ b/src/test/scala/io/github/nafg/scalacoptions/OptionsSpec.scala
@@ -1,0 +1,53 @@
+package io.github.nafg.scalacoptions
+
+import scala.collection.immutable.SortedSet
+
+import coursier.core.Version
+import munit.FunSuite
+
+
+class OptionsSpec extends FunSuite {
+  private def matchingVersions(toFlags: String => List[String]): SortedSet[String] =
+    SortedSet(ScalacOptions.versionMap.keys.filter(toFlags(_).nonEmpty).toSeq: _*)
+
+  private def range(from: String, to: String): SortedSet[String] =
+    SortedSet(ScalacOptions.sortedVersionMap.keys.toSeq: _*)
+      .from(new Version(from))
+      .until(new Version(to))
+      .map(_.repr)
+
+  test("V3_2_+ matches Scala 3.2 and later") {
+    assertEquals(
+      matchingVersions { v =>
+        ScalacOptions.all(v)((opts: options.V3_2_+) => opts.javaOutputVersion("8"))
+      },
+      range("3.2.0", "4.0.0")
+    )
+  }
+
+  test("V3_3 matches only Scala 3.3.x") {
+    assertEquals(
+      matchingVersions { v =>
+        ScalacOptions.all(v)((opts: options.V3_3) => opts.javaOutputVersion("8"))
+      },
+      range("3.3.0", "3.4.0")
+    )
+  }
+
+  test("V3_4_2_+ matches Scala 3.4.2 through end of 3.4.x") {
+    assertEquals(
+      matchingVersions { v =>
+        ScalacOptions.all(v)((opts: options.V3_4_2_+) => opts.Wshadow("all"))
+      },
+      range("3.4.2", "3.5.0")
+    )
+  }
+
+  test("javaOutputVersion produces -java-output-version:VALUE") {
+    for (version <- Seq("3.2.0", "3.5.0", "3.8.3"))
+      assertEquals(
+        ScalacOptions.all(version)((opts: options.V3_2_+) => opts.javaOutputVersion("8")),
+        List("-java-output-version:8")
+      )
+  }
+}


### PR DESCRIPTION
## Summary

Introduce a new layer of range traits that span majors within an epoch — `V3_2_+`, `V3_3_+`, …, `V3_8_+` for V3 (and `V2_11_+`, `V2_12_+`, `V2_13_+` for V2). `V3_2_+` is to "Scala 3.2 and up (< 4.0)" what `V3_1_2_+` is to "3.1.2 and up (< 3.2)".

## Hierarchy

```
Common
└── V3
    └── V3_0_+ ← V3_1_+ ← V3_2_+ ← V3_3_+ ← … ← V3_8_+   (new)
        └── V3_M extends V3_M_+
            └── V3_M_0_+ ← V3_M_1_+ ← …                 (unchanged)
                └── V3_M_P (concrete)
```

The patch-range chain inside each major is unchanged.

## Effect on generated code

Settings common to V3_2..V3_<latest> lift onto `V3_2_+` and are no longer redundantly defined on every per-major trait. Concretely, after this change `javaOutputVersion(choice: String)` lives on `V3_1_2_+` (within V3_1) and `V3_2_+` (across V3_2..V3_8), instead of being duplicated on each of V3_2, V3_3, V3_4, V3_5, V3_6, V3_7, V3_8.

This unblocks dogfooded build code — `(opts: options.V3_2_+) => opts.javaOutputVersion("8")` now works as a single line covering the whole "Scala 3.2 onward" range.

## Implementation

`Generator.parseAllOutputs` gains a parallel `groupedMinorRange` / `commonMinorRange` / `minorRangeContainers` layer that mirrors the existing intra-major `groupedRange` / `rangeContainers` one level up. `majorContainers` is re-parented onto its corresponding `minorRangeContainer`.

## Test plan

- [ ] CI green across 2.12.x / 2.13.x / 3.3.x
- [ ] Generated diff under `target/scala-*/src_managed/.../options/` shows new `V*_+` traits and de-duplication of common settings on V3_M traits
