### PR TITLE
chore(build): use typed scalacOptions DSL for -release/-java-output-version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,12 @@ ThisBuild / crossScalaVersions := Seq("2.12.21", "2.13.18", "3.3.7")
 ThisBuild / scalaVersion       := "2.12.21"
 ThisBuild / scalacOptions ++=
   ScalacOptions.all(scalaVersion.value)((opts: options.Common) => opts.deprecation ++ opts.feature)
-ThisBuild / scalacOptions ++= Seq("-release", "8")
+ThisBuild / scalacOptions ++=
+  ScalacOptions.all(scalaVersion.value)(
+    (opts: options.V2_12_17_+) => opts.release("8"),
+    (opts: options.V2_13_9_+) => opts.release("8"),
+    (opts: options.V3_2_+) => opts.javaOutputVersion("8")
+  )
 
 ThisBuild / organization := "io.github.nafg.scalac-options"
 
@@ -126,7 +131,7 @@ lazy val launcher =
 lazy val library = (project in file("."))
   .dependsOn(launcher % Test)
   .settings(
-    name := "scalac-options",
+    name               := "scalac-options",
     libraryDependencies ++= Seq(
       ("io.get-coursier" %% "coursier-core" % "2.1.24").cross(CrossVersion.for3Use2_13),
       "org.scalameta"    %% "munit"         % "1.3.0" % Test


### PR DESCRIPTION
## Summary

Replace `Seq("-release", "8")` in `build.sbt` with the typed DSL, dispatched per Scala version:
  - `(opts: options.V2_12_17_+) => opts.release("8")`
  - `(opts: options.V2_13_9_+)  => opts.release("8")`
  - `(opts: options.V3_2_+)     => opts.javaOutputVersion("8")`

This is the original motivation for #382: "Scala 3.2 and up" can now be expressed as a single trait, so we can dogfood the typed API for our own JDK 8 target. The 0.6.0 dependency bump itself landed separately in #384.

## Effect on emitted scalac flags

| Scala     | Before              | After                    |
|-----------|---------------------|--------------------------|
| 2.12.21   | `-release 8`        | `-release:8`             |
| 2.13.18   | `-release 8`        | `-release:8`             |
| 3.3.7     | `-release 8`        | `-java-output-version:8` |

The colon vs. space form on 2.x reflects what each scalac version actually accepts at that minor range; 3.3.7 picks up the Scala 3.2+ replacement flag instead of the deprecated `-release` alias.

## Test plan

- [x] Local: `sbt '+Test/compile'` clean across 2.12.21 / 2.13.18 / 3.3.7
- [x] Local: `sbt '++ <ver>; show scalacOptions'` prints the expected flag for each version
- [ ] CI green