### PR TITLE
Pin Scala 3 to the 3.3 LTS line for Scala Steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,7 @@
+# Stay on the Scala 3 LTS line: building a library on a Next-line compiler
+# raises the minimum compiler version for all consumers.
+# Lift to "3.9." once 3.9.0 LTS is released.
+updates.pin = [
+  { groupId = "org.scala-lang", artifactId = "scala3-library_3", version = "3.3." },
+  { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1_3", version = "3.3." }
+]


### PR DESCRIPTION
Adds the canonical `.scala-steward.conf` used across the nafg library repos, pinning `scala3-library` (and its Scala.js variant) to the `3.3.` LTS line.

Rationale: this is a library, so building on a Next-line Scala 3 compiler would raise the minimum compiler version for every consumer. The pin holds us on 3.3 LTS until Scala 3.9.0 (the next LTS) ships, at which point the pin gets lifted to `3.9.`.

Note: the companion JDK-17 CI bump done in the sibling repos is **not** needed here — this repo's `ci.sbt` already sets `githubWorkflowJavaVersions := Seq(JavaSpec.zulu("17"))`, so the sbt 2.x JDK requirement is already satisfied and the sbt-2 Steward PR is not blocked on it. Left as `zulu@17` deliberately to avoid renaming the required check names in `.mergify.yml` / branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added project configuration to keep Scala 3 dependencies aligned with the 3.3.x version line.
  * Documented the project’s Scala 3 LTS version pinning policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->