### PR TITLE
Revert "Pin Scala 3 to LTS via .scala-steward.conf"

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,7 +1,0 @@
-# Stay on the Scala 3 LTS line: building a library on a Next-line compiler
-# raises the minimum compiler version for all consumers.
-# Lift to "3.9." once 3.9.0 LTS is released.
-updates.pin = [
-  { groupId = "org.scala-lang", artifactId = "scala3-library_3", version = "3.3." },
-  { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1_3", version = "3.3." }
-]


### PR DESCRIPTION
Reverts nafg/scalac-options#422

Scala Steward's default config already prevents LTS-to-Next Scala 3 bumps, and the Scala.js artifact gap that motivated the pin was fixed upstream on 2026-07-13, so the per-repo `.scala-steward.conf` is unneeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)